### PR TITLE
Remove unused FileHandler.writeToFile method

### DIFF
--- a/app/src/main/java/de/sopa/helper/FileHandler.java
+++ b/app/src/main/java/de/sopa/helper/FileHandler.java
@@ -26,23 +26,6 @@ public class FileHandler {
         this.context = context;
     }
 
-    public void writeToFile(String filename, String[] strings) throws IOException {
-
-        FileOutputStream fileOutputStream = new FileOutputStream(filename);
-
-        for (int i = 0; i < strings.length; i++) {
-            String string = strings[i];
-            fileOutputStream.write((string).getBytes());
-
-            if (i < strings.length) {
-                fileOutputStream.write('\n');
-            }
-        }
-
-        fileOutputStream.close();
-    }
-
-
     public String[] readFromFile(String filename) throws IOException {
 
         List<String> lines = new ArrayList<>();


### PR DESCRIPTION
I saw that this method was used in previous revisions but isn't used anymore. So you might want to delete it.

BTW: The line `if (i < strings.length)` was not really needed anyway since it always evaluated to `true`, as this is the same condition as in the `for` loop definition.
I guess this should've been an `if (i < strings.length - 1)` instead? But it doesn't matter now anyway since the whole method would be removed with this PR anyway :wink:.