### PR TITLE
General code quality fix-1

### DIFF
--- a/app/src/main/java/de/sopa/database/LevelInfoTable.java
+++ b/app/src/main/java/de/sopa/database/LevelInfoTable.java
@@ -27,6 +27,8 @@ class LevelInfoTable {
         + " integer primary key autoincrement, " + COLUMN_SCORE_POINTS
         + " integer not null," + COLUMN_SCORE_SOLVED_LEVELS + " integer not null);";
 
+    private LevelInfoTable() {}
+
     static void onCreate(SQLiteDatabase database) {
 
         database.execSQL(DATABASE_CREATE);

--- a/app/src/main/java/de/sopa/helper/LevelTranslator.java
+++ b/app/src/main/java/de/sopa/helper/LevelTranslator.java
@@ -43,6 +43,7 @@ public class LevelTranslator {
 
                 case 2:
                     level.setTilesCount(Integer.parseInt(string[2]));
+                    break;
 
                 default:
                     break;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1118 - Utility classes should not have public constructors.
squid:S128 - Switch cases should end with an unconditional "break" statement. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S128

Please let me know if you have any questions.

Faisal Hameed
