### PR TITLE
General code quality fix-2

### DIFF
--- a/app/src/main/java/de/sopa/scene/game/GameFieldView.java
+++ b/app/src/main/java/de/sopa/scene/game/GameFieldView.java
@@ -225,7 +225,7 @@ class GameFieldView extends Entity {
 
         modifierFinished++;
 
-        if (modifierFinished == countModifier | now) {
+        if (modifierFinished == countModifier || now) {
             active = false;
             gameService.notifyAllObserver();
         }

--- a/app/src/main/java/de/sopa/scene/justplay/JustPlayLostScene.java
+++ b/app/src/main/java/de/sopa/scene/justplay/JustPlayLostScene.java
@@ -166,7 +166,7 @@ class JustPlayLostScene extends BaseScene {
         attachChild(scoreText);
 
         score = new Text((float) (camera.getWidth() * 0.6), (float) (camera.getHeight() * 0.45),
-                resourcesManager.justPlayScoreFont, "" + currentScore[0], 8, vbom);
+                resourcesManager.justPlayScoreFont, Integer.toString(currentScore[0]), 8, vbom);
         score.setColor(BLACK);
         attachChild(score);
 

--- a/app/src/main/java/de/sopa/scene/justplay/JustPlayScoreScene.java
+++ b/app/src/main/java/de/sopa/scene/justplay/JustPlayScoreScene.java
@@ -96,7 +96,7 @@ class JustPlayScoreScene extends BaseScene {
         attachChild(scoreText);
 
         score = new Text((float) (camera.getWidth() * 0.65), (float) (camera.getHeight() * 0.45),
-                resourcesManager.justPlayScoreFont, "" + currentScore[0], 8, vbom);
+                resourcesManager.justPlayScoreFont, Integer.toString(currentScore[0]), 8, vbom);
         score.setColor(BLACK);
         attachChild(score);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2131- Primitives should not be boxed just for "String" conversion.
squid:S2178 - Short-circuit logic should be used in boolean contexts.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S2178

Please let me know if you have any questions.

Faisal Hameed
